### PR TITLE
Automation for Release building

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  main:
+    name: Create Protobuf generated files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup GO
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14.17.1
+      - run: npm install -g typescript
+
+      - name: Setup protoc-gen-go
+        uses: arduino/setup-protoc@v1
+
+      - name: Add Protobuf files
+        run: |
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.27.1
+          go mod download
+          make generate
+
+      - name: Add proto and pb files to release
+        run: |
+          zip generated_proto_files.zip ./fig -r
+          zip generated_pb_go.zip ./pb -r
+
+      - name: Setup Graph Proto as Schema
+        run: |
+          git clone https://github.com/figment-networks/graph-proto-as-schema
+          cd graph-proto-as-schema
+          yarn install
+          tsc
+          mkdir outp
+          node ./dist/index.js -o ./outp  -d ../fig/tendermint/codec/v1
+
+      - name: Add ts files to release
+        run: |
+          zip generated_ts_files.zip ./graph-proto-as-schema/outp -r
+
+      - name: Graph-ts
+        run: |
+          git clone --branch cosmos --single-branch https://github.com/figment-networks/graph-ts
+          cp -r ./graph-proto-as-schema/outp ./graph-ts/chain
+
+      - name: Graph-as-to-rust
+        run: |
+          git clone --branch tendermint --single-branch https://github.com/figment-networks/graph-as-to-rust
+          cd graph-as-to-rust
+          yarn install
+          yarn tsc && node run.js
+
+      - name: Add Rust files to release
+        run: |
+          zip generated_rust_tendermint.zip ./graph-as-to-rust/tendermint.rs
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          artifacts: "generated_*.zip"
+          allowUpdates: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Typescript
         uses: actions/setup-node@v3
         with:
-          node-version: 14.17.1
+          node-version: 16 
       - run: npm install -g typescript
 
       - name: Setup protoc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: 1.17
 
-      - name: Setup Node
+      - name: Setup Typescript
         uses: actions/setup-node@v3
         with:
           node-version: 14.17.1
@@ -26,7 +26,7 @@ jobs:
 
       - name: Setup protoc-gen-go
         uses: arduino/setup-protoc@v1
-
+      
       - name: Add Protobuf files
         run: |
           go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.27.1
@@ -40,23 +40,27 @@ jobs:
 
       - name: Setup Graph Proto as Schema
         run: |
+          mkdir repos && cd repos
           git clone https://github.com/figment-networks/graph-proto-as-schema
           cd graph-proto-as-schema
           yarn install
           tsc
           mkdir outp
-          node ./dist/index.js -o ./outp  -d ../fig/tendermint/codec/v1
+          node ./dist/index.js -o ./outp  -d ../../fig/tendermint/codec/v1 --typescript_namespace tendermint
 
       - name: Add ts files to release
+        working-directory: repos
         run: |
-          zip generated_ts_files.zip ./graph-proto-as-schema/outp -r
+          zip ../generated_ts_files.zip ./graph-proto-as-schema/outp -r
 
       - name: Graph-ts
+        working-directory: repos
         run: |
           git clone --branch cosmos --single-branch https://github.com/figment-networks/graph-ts
           cp -r ./graph-proto-as-schema/outp ./graph-ts/chain
 
       - name: Graph-as-to-rust
+        working-directory: repos
         run: |
           git clone --branch tendermint --single-branch https://github.com/figment-networks/graph-as-to-rust
           cd graph-as-to-rust
@@ -64,8 +68,9 @@ jobs:
           yarn tsc && node run.js
 
       - name: Add Rust files to release
+        working-directory: repos
         run: |
-          zip generated_rust_tendermint.zip ./graph-as-to-rust/tendermint.rs
+          zip ../generated_rust_tendermint.zip ./graph-as-to-rust/tendermint.rs
 
       - name: Create Release
         uses: ncipollo/release-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 14.17.1
       - run: npm install -g typescript
 
-      - name: Setup protoc-gen-go
+      - name: Setup protoc
         uses: arduino/setup-protoc@v1
       
       - name: Add Protobuf files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,11 +66,12 @@ jobs:
           cd graph-as-to-rust
           yarn install
           yarn tsc && node run.js
+          mv tendermint.rs generated.rs
 
       - name: Add Rust files to release
         working-directory: repos
         run: |
-          zip ../generated_rust_tendermint.zip ./graph-as-to-rust/tendermint.rs
+          zip ../generated_rust_tendermint.zip ./graph-as-to-rust/generated.rs
 
       - name: Create Release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
https://figmentio.atlassian.net/browse/GRAPH-337

Here's an example of what a release looks like. It targets the main branch of graph-proto-as-schema, the cosmos branch of graph-ts, and the tendermint branch of graph-as-to-rust. It doesn't manipulate any files, it just copies the output across the steps as requires and adds them to a zip file

<img width="1350" alt="protobuf_releases" src="https://user-images.githubusercontent.com/7063963/164086829-84470cd4-26dc-4fe1-b0b1-b59b9cdd5002.png">

